### PR TITLE
Fix: Correct AgentOrchestrator instantiation

### DIFF
--- a/lib/agent-architecture/index.ts
+++ b/lib/agent-architecture/index.ts
@@ -1,3 +1,4 @@
+import { OpenAIService } from '@/lib/services/openai'; // Added
 import { AgentOrchestrator } from './orchestrator';
 
 export { AgentOrchestrator } from './orchestrator';
@@ -5,8 +6,7 @@ export * from './core/types';
 
 // Factory function for easy initialization
 export function createAgentOrchestrator(
-  firecrawlApiKey: string,
-  openaiApiKey: string
+  openaiService: OpenAIService // Changed
 ) {
-  return new AgentOrchestrator(firecrawlApiKey, openaiApiKey);
+  return new AgentOrchestrator(openaiService); // Changed
 }


### PR DESCRIPTION
This commit fixes a build error caused by an incorrect instantiation of AgentOrchestrator in `lib/agent-architecture/index.ts`.

The `createAgentOrchestrator` factory function in that file was still using the old constructor signature (expecting API keys) after `AgentOrchestrator` was refactored to accept an `OpenAIService` instance.

This has been corrected by:
- Updating `createAgentOrchestrator` to accept an `OpenAIService` instance.
- Passing the `OpenAIService` instance to the `AgentOrchestrator` constructor.

The main application flow in `AgentEnrichmentStrategy` already instantiates `AgentOrchestrator` directly and correctly. This change ensures the factory function is also correct, preventing build failures.